### PR TITLE
Optimize Docker image with Alpine Linux (750MB → 190MB)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,52 @@
+# Git files
+.git
+.gitignore
+
+# Documentation
+README.md
+LICENSE
+CONTRIBUTING.md
+
+# Python cache
+__pycache__
+*.pyc
+*.pyo
+*.pyd
+.Python
+pip-log.txt
+pip-delete-this-directory.txt
+.tox/
+.coverage
+.coverage.*
+.cache
+coverage.xml
+*.cover
+.hypothesis/
+.pytest_cache/
+
+# Virtual environments
+venv/
+env/
+ENV/
+
+# IDE files
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# OS files
+.DS_Store
+Thumbs.db
+
+# Docker files
+docker-compose.yml
+docker-compose.yaml
+Dockerfile
+.dockerignore
+
+# Temporary files
+*.tmp
+*.temp
+*.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,23 +1,30 @@
-FROM python:3.11-slim
+# Alpine-based ultra-lightweight version
+FROM python:3.11-alpine as builder
 
-# Install FFmpeg
-RUN apt-get update && \
-    apt-get install -y ffmpeg && \
-    rm -rf /var/lib/apt/lists/*
+# Install build dependencies
+RUN apk add --no-cache gcc musl-dev linux-headers
 
-# Set working directory
 WORKDIR /app
+COPY requirements.txt .
+RUN pip install --user --no-cache-dir -r requirements.txt
+
+# Final stage
+FROM python:3.11-alpine
+
+# Install only runtime dependencies
+RUN apk add --no-cache ffmpeg
+
+WORKDIR /app
+
+# Copy Python dependencies from builder
+COPY --from=builder /root/.local /root/.local
+ENV PATH=/root/.local/bin:$PATH
 
 # Copy application files
 COPY app.py .
 COPY templates/ templates/
 COPY static/ static/
 
-# Install Python dependencies
-RUN pip install --no-cache-dir flask
-
-# Expose port
 EXPOSE 8338
 
-# Run the application
 CMD ["python", "app.py"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+Flask==3.0.0
+Werkzeug==3.0.1


### PR DESCRIPTION
## Summary
This PR reduces the Docker image size by ~75% using Alpine Linux.

## Changes
- Switch from Debian to Alpine Linux base image
- Multi-stage build to exclude build dependencies  
- Add explicit requirements.txt for better dependency management
- Add .dockerignore to reduce build context size

## Results
- **Before**: ~750MB
- **After**: ~190MB
- All functionality tested and working