### PR TITLE
Add feature: Add ability to filter by tags

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN pip install --user --no-cache-dir -r requirements.txt
 FROM python:3.11-alpine
 
 # Install only runtime dependencies
-RUN apk add --no-cache wavpack
+RUN apk add --no-cache wavpack sqlite
 
 WORKDIR /app
 
@@ -30,6 +30,7 @@ COPY gunicorn_config.py .
 COPY core/ core/
 COPY templates/ templates/
 COPY static/ static/
+COPY migrations/ /migrations/
 
 EXPOSE 8338
 

--- a/app.py
+++ b/app.py
@@ -40,6 +40,12 @@ from werkzeug.middleware.proxy_fix import ProxyFix
 import signal
 import sys
 
+# Database and scanner imports
+import core.database as db
+from core.scanner import scanner_status, scan_directory_in_background
+from core.watcher import start_watcher
+
+
 from config import (
     MUSIC_DIR, OWNER_UID, OWNER_GID, PORT, HOST,
     AUDIO_EXTENSIONS, MIME_TYPES, FORMAT_METADATA_CONFIG,
@@ -70,8 +76,23 @@ from core.album_art.manager import (
     prepare_batch_album_art_change, record_batch_album_art_history
 )
 from core.batch.processor import process_folder_files
-
+ 
 app = Flask(__name__)
+
+# ==================
+# STARTUP PROCEDURES
+# ==================
+
+def initialize_app():
+    """Initialize database and start background services."""
+    logger.info("Initializing application...")
+    db.init_db()
+    start_watcher()
+    if db.get_file_count() == 0:
+        logger.info("Database is empty. Starting initial library scan in background.")
+        scan_directory_in_background()
+
+initialize_app()
 
 # Configure for reverse proxy
 # This ensures Flask correctly interprets headers set by the reverse proxy
@@ -318,6 +339,25 @@ def get_tree(subpath=''):
         return jsonify({'error': 'Invalid path'}), 403
     except Exception as e:
         logger.error(f"Error building tree: {e}")
+        return jsonify({'error': str(e)}), 500
+
+@app.route('/files')
+def query_files():
+    """Query files from the database with filters and pagination."""
+    try:
+        page = int(request.args.get('page', 1))
+        limit = int(request.args.get('limit', 1000))
+        
+        filters = {}
+        for key, value in request.args.items():
+            if key.lower() not in ['page', 'limit']:
+                filters[key] = value
+        result = db.query_files(filters, page, limit)
+        
+        return jsonify(result)
+        
+    except Exception as e:
+        logger.error(f"Error querying files: {e}")
         return jsonify({'error': str(e)}), 500
 
 @app.route('/files/<path:folder_path>')
@@ -1036,7 +1076,46 @@ def delete_field_from_folder():
         return jsonify({'error': 'Invalid path'}), 403
     except Exception as e:
         logger.error(f"Error in batch field deletion: {e}")
+        return jsonify({{'error': str(e)}}), 500
+
+# =================
+# SCANNING & TAGS API
+# =================
+
+@app.route('/admin/scan', methods=['POST'])
+def trigger_scan():
+    """Trigger a full library scan."""
+    if scanner_status['status'] == 'scanning':
+        return jsonify({'status': 'error', 'message': 'Scan already in progress'}), 409
+    
+    scan_directory_in_background()
+    return jsonify({'status': 'success', 'message': 'Scan started in background'})
+
+@app.route('/admin/scan/status')
+def get_scan_status():
+    """Get the current status of the library scanner."""
+    return jsonify(scanner_status)
+
+@app.route('/tags')
+def get_all_tags():
+    """Get a list of all available tag types."""
+    try:
+        tags = db.get_tags()
+        return jsonify({'tags': tags})
+    except Exception as e:
+        logger.error(f"Error getting tags: {e}")
         return jsonify({'error': str(e)}), 500
+
+@app.route('/tags/<tag_name>/values')
+def get_tag_values(tag_name):
+    """Get all unique values for a specific tag."""
+    try:
+        values = db.get_tag_values(tag_name)
+        return jsonify({'tag': tag_name, 'values': values})
+    except Exception as e:
+        logger.error(f"Error getting tag values for {tag_name}: {e}")
+        return jsonify({'error': str(e)}), 500
+
 
 # =================
 # HISTORY ENDPOINTS

--- a/core/database.py
+++ b/core/database.py
@@ -1,0 +1,175 @@
+# Metadata Remote - Intelligent audio metadata editor
+# Copyright (C) 2025 Dr. William Nelson Leonard
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import sqlite3
+import os
+import math
+from typing import Dict, List, Any
+
+from config import MUSIC_DIR, logger
+
+# Database path configuration
+DATA_DIR = os.path.abspath(os.path.join(MUSIC_DIR, '..', 'data'))
+DB_PATH = os.path.join(DATA_DIR, 'music.db')
+MIGRATIONS_DIR = os.path.abspath(os.path.join(MUSIC_DIR, '..', 'migrations'))
+
+def get_db_connection():
+    """Get a new database connection."""
+    conn = sqlite3.connect(DB_PATH, timeout=10)
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA foreign_keys = ON;")
+    return conn
+
+def init_db():
+    """Initialize the database and run migrations."""
+    os.makedirs(DATA_DIR, exist_ok=True)
+    conn = get_db_connection()
+    try:
+        migration_file = os.path.join(MIGRATIONS_DIR, '001_init.sql')
+        if os.path.exists(migration_file):
+            with open(migration_file, 'r') as f:
+                conn.executescript(f.read())
+            conn.commit()
+            logger.info("Database initialized and migrations applied.")
+            populate_tags_table()
+        else:
+            logger.error(f"Migration file not found: {migration_file}")
+    finally:
+        conn.close()
+
+def populate_tags_table():
+    """Pre-populate the tags table with standard tag names."""
+    conn = get_db_connection()
+    try:
+        cursor = conn.cursor()
+        standard_tags = [
+            'TITLE', 'ARTIST', 'ALBUM', 'GENRE'
+        ]
+        for tag in standard_tags:
+            cursor.execute("INSERT OR IGNORE INTO tags (tag_name) VALUES (?)", (tag,))
+        conn.commit()
+        logger.info("Standard tags populated.")
+    finally:
+        conn.close()
+
+def get_file_count() -> int:
+    conn = get_db_connection()
+    try:
+        return conn.execute("SELECT COUNT(*) FROM files").fetchone()[0]
+    except sqlite3.OperationalError:
+        return 0 # Table might not exist yet
+    finally:
+        conn.close()
+
+def index_file(path: str, name: str, folder: str, size: int, date: int, tags: Dict[str, str]):
+    conn = get_db_connection()
+    try:
+        with conn:
+            cursor = conn.cursor()
+            cursor.execute("""
+                INSERT INTO files (path, name, folder, size, date)
+                VALUES (?, ?, ?, ?, ?)
+                ON CONFLICT(path) DO UPDATE SET
+                name=excluded.name, folder=excluded.folder, size=excluded.size, date=excluded.date
+            """, (path, name, folder, size, date))
+            
+            cursor.execute("SELECT file_id FROM files WHERE path = ?", (path,))
+            file_id = cursor.fetchone()[0]
+            
+            cursor.execute("DELETE FROM file_tags WHERE file_id = ?", (file_id,))
+            
+            for tag_name, tag_value in tags.items():
+                tag_name_upper = tag_name.upper()
+                if tag_value:
+                    cursor.execute("INSERT OR IGNORE INTO tags (tag_name) VALUES (?)", (tag_name_upper,))
+                    cursor.execute("""
+                        INSERT INTO file_tags (file_id, tag_id, tag_value)
+                        VALUES (?, (SELECT tag_id FROM tags WHERE tag_name = ?), ?)
+                    """, (file_id, tag_name_upper, str(tag_value)))
+    finally:
+        conn.close()
+
+def remove_file(path: str):
+    conn = get_db_connection()
+    try:
+        with conn:
+            conn.execute("DELETE FROM files WHERE path = ?", (path,))
+    finally:
+        conn.close()
+
+def query_files(filters: Dict[str, str], page: int, limit: int) -> Dict[str, Any]:
+    conn = get_db_connection()
+    try:
+        base_query = "FROM files f"
+        where_clauses = []
+        params = []
+        
+        tag_filters = {k: v for k, v in filters.items() if k not in ['name', 'folder']}
+        
+        where_clauses.append("f.folder = ?")
+        params.append(filters['folder'])
+
+        for i, (tag_name, tag_value) in enumerate(tag_filters.items()):
+             if tag_value == '/null':
+                 # Find files that DO NOT have the tag or have it with an empty value.
+                 # We do this by excluding files that DO have the tag with a non-empty value.
+                 where_clauses.append(f"""
+                     f.file_id NOT IN (
+                         SELECT ft.file_id FROM file_tags ft JOIN tags t ON ft.tag_id = t.tag_id
+                         WHERE t.tag_name = ? AND ft.tag_value IS NOT NULL AND ft.tag_value != ''
+                     )
+                 """)
+                 params.append(tag_name.upper())
+             else:
+                 join_alias = f"ft{i}"
+                 tag_alias = f"t{i}"
+                 base_query += f" JOIN file_tags {join_alias} ON f.file_id = {join_alias}.file_id JOIN tags {tag_alias} ON {join_alias}.tag_id = {tag_alias}.tag_id"
+                 where_clauses.append(f"{tag_alias}.tag_name = ? AND {join_alias}.tag_value LIKE ?")
+                 params.extend([tag_name.upper(), f"%{tag_value}%"])
+
+        where_sql = "WHERE " + " AND ".join(where_clauses) if where_clauses else ""
+
+        count_query = f"SELECT COUNT(DISTINCT f.file_id) {base_query} {where_sql}"
+        total = conn.execute(count_query, params).fetchone()[0]
+        
+        offset = (page - 1) * limit
+        files_query = f"SELECT DISTINCT f.path, f.name, f.folder, f.size, f.date {base_query} {where_sql} ORDER BY f.folder, f.name LIMIT ? OFFSET ?"
+        params.extend([limit, offset])
+        
+        files = [dict(row) for row in conn.execute(files_query, params).fetchall()]
+        total_pages = math.ceil(total / limit) if limit > 0 else 0
+        
+        return {
+            "files": files,
+            "pagination": { "page": page, "limit": limit, "total": total, "totalPages": total_pages, "hasNext": page < total_pages, "hasPrev": page > 1 }
+        }
+    finally:
+        conn.close()
+
+def get_tags() -> List[str]:
+    conn = get_db_connection()
+    try:
+        return [row['tag_name'] for row in conn.execute("SELECT tag_name FROM tags ORDER BY tag_name").fetchall()]
+    finally:
+        conn.close()
+
+def get_tag_values(tag_name: str) -> List[str]:
+    conn = get_db_connection()
+    try:
+        query = "SELECT DISTINCT ft.tag_value FROM file_tags ft JOIN tags t ON ft.tag_id = t.tag_id WHERE t.tag_name = ? ORDER BY ft.tag_value"
+        return [row['tag_value'] for row in conn.execute(query, (tag_name.upper(),)).fetchall()]
+    finally:
+        conn.close()

--- a/core/scanner.py
+++ b/core/scanner.py
@@ -1,0 +1,93 @@
+# Metadata Remote - Intelligent audio metadata editor
+# Copyright (C) 2025 Dr. William Nelson Leonard
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import os
+import threading
+import time
+from typing import Dict, Any
+
+from config import MUSIC_DIR, AUDIO_EXTENSIONS, logger
+import core.database as db
+from core.metadata.mutagen_handler import mutagen_handler
+
+scanner_status: Dict[str, Any] = {
+    "status": "idle", # idle, scanning, finished
+    "progress": 0,
+    "total_files": 0,
+    "processed_files": 0,
+    "start_time": None,
+    "end_time": None,
+    "errors": []
+}
+
+def scan_directory_in_background():
+    """Starts a full library scan in a background thread."""
+    if scanner_status["status"] == "scanning":
+        logger.warning("Scan is already in progress.")
+        return
+    
+    thread = threading.Thread(target=scan_directory, daemon=True)
+    thread.start()
+
+def scan_directory():
+    """Scans the entire music directory and indexes files."""
+    logger.info("Starting full library scan...")
+    scanner_status.update({ "status": "scanning", "progress": 0, "total_files": 0, "processed_files": 0, "start_time": time.time(), "errors": [] })
+
+    try:
+        audio_files = [os.path.join(root, file) for root, _, files in os.walk(MUSIC_DIR) for file in files if file.lower().endswith(AUDIO_EXTENSIONS)]
+        scanner_status["total_files"] = len(audio_files)
+        
+        for i, filepath in enumerate(audio_files):
+            try:
+                index_file(filepath)
+            except Exception as e:
+                error_msg = f"Failed to index {filepath}: {e}"
+                logger.error(error_msg)
+                scanner_status["errors"].append(error_msg)
+            
+            scanner_status["processed_files"] = i + 1
+            scanner_status["progress"] = (i + 1) / scanner_status["total_files"] * 100 if scanner_status["total_files"] > 0 else 100
+    
+    except Exception as e:
+        logger.error(f"Fatal error during scan: {e}")
+        scanner_status["errors"].append(f"Fatal error: {e}")
+    
+    finally:
+        scanner_status.update({ "status": "finished", "end_time": time.time(), "progress": 100 })
+        duration = scanner_status["end_time"] - scanner_status["start_time"]
+        logger.info(f"Library scan finished in {duration:.2f} seconds.")
+
+def index_file(filepath: str):
+    """Reads metadata and indexes a single file."""
+    try:
+        rel_path = os.path.relpath(filepath, MUSIC_DIR)
+        stat = os.stat(filepath)
+        tags_to_index = mutagen_handler.read_existing_metadata(filepath)
+        standard_tags = {k: v for k, v in tags_to_index.items() if k != 'format' and v}
+        db.index_file(path=rel_path, name=os.path.basename(filepath), folder=os.path.dirname(rel_path), size=stat.st_size, date=int(stat.st_mtime), tags=standard_tags)
+    except Exception as e:
+        logger.error(f"Error indexing file {filepath}: {e}")
+        raise
+
+def remove_file_from_index(filepath: str):
+    """Removes a file from the database index."""
+    try:
+        rel_path = os.path.relpath(filepath, MUSIC_DIR)
+        db.remove_file(rel_path)
+        logger.info(f"Removed {rel_path} from index.")
+    except Exception as e:
+        logger.error(f"Error removing file {filepath} from index: {e}")

--- a/core/watcher.py
+++ b/core/watcher.py
@@ -1,0 +1,54 @@
+# Metadata Remote - Intelligent audio metadata editor
+# Copyright (C) 2025 Dr. William Nelson Leonard
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import threading
+from watchdog.observers import Observer
+from watchdog.events import FileSystemEventHandler
+
+from config import MUSIC_DIR, logger, AUDIO_EXTENSIONS
+from core.scanner import index_file, remove_file_from_index
+
+class MusicLibraryEventHandler(FileSystemEventHandler):
+    """Handles filesystem events for the music library."""
+    def on_created(self, event):
+        if not event.is_directory and event.src_path.lower().endswith(AUDIO_EXTENSIONS):
+            logger.info(f"File created: {event.src_path}, indexing...")
+            index_file(event.src_path)
+
+    def on_modified(self, event):
+        if not event.is_directory and event.src_path.lower().endswith(AUDIO_EXTENSIONS):
+            logger.info(f"File modified: {event.src_path}, re-indexing...")
+            index_file(event.src_path)
+
+    def on_deleted(self, event):
+        if not event.is_directory and event.src_path.lower().endswith(AUDIO_EXTENSIONS):
+            logger.info(f"File deleted: {event.src_path}, removing from index...")
+            remove_file_from_index(event.src_path)
+
+    def on_moved(self, event):
+        if not event.is_directory:
+            if event.src_path.lower().endswith(AUDIO_EXTENSIONS):
+                remove_file_from_index(event.src_path)
+            if event.dest_path.lower().endswith(AUDIO_EXTENSIONS):
+                index_file(event.dest_path)
+
+def start_watcher():
+    """Starts the filesystem watcher in a background thread."""
+    observer = Observer()
+    observer.schedule(MusicLibraryEventHandler(), MUSIC_DIR, recursive=True)
+    thread = threading.Thread(target=observer.start, daemon=True)
+    thread.start()
+    logger.info(f"Started filesystem watcher for {MUSIC_DIR}")

--- a/migrations/001_init.sql
+++ b/migrations/001_init.sql
@@ -1,0 +1,29 @@
+-- Tag types (ARTIST, ALBUM, GENRE, etc.)
+CREATE TABLE IF NOT EXISTS tags (
+    tag_id INTEGER PRIMARY KEY,
+    tag_name TEXT UNIQUE NOT NULL
+);
+
+-- Music files
+CREATE TABLE IF NOT EXISTS files (
+    file_id INTEGER PRIMARY KEY,
+    path TEXT UNIQUE NOT NULL,
+    name TEXT,
+    folder TEXT,
+    size INTEGER,
+    date INTEGER
+);
+
+-- File-to-tag mappings with values
+CREATE TABLE IF NOT EXISTS file_tags (
+    file_id INTEGER,
+    tag_id INTEGER,
+    tag_value TEXT,
+    FOREIGN KEY (file_id) REFERENCES files(file_id) ON DELETE CASCADE,
+    FOREIGN KEY (tag_id) REFERENCES tags(tag_id),
+    PRIMARY KEY (file_id, tag_id)
+);
+
+-- Performance indexes
+CREATE INDEX IF NOT EXISTS idx_file_tags_lookup ON file_tags(tag_id, tag_value);
+CREATE INDEX IF NOT EXISTS idx_files_name ON files(name);

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ MarkupSafe==3.0.2
 mutagen==1.47.0
 Pillow>=10.0.0
 Werkzeug==3.0.1
+watchdog>=3.0.0

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -926,6 +926,12 @@ input:autofill {
     transform: scale(1.05);
 }
 
+.control-icon svg {
+    display: block;
+    width: 14px;
+    height: 14px;
+}
+
 .sort-direction-btn:focus,
 .sort-direction-btn:active {
     background: none !important;
@@ -989,8 +995,13 @@ input:autofill {
 
 .filter-container.active {
     display: block;
-    max-height: 60px; /* Enough for the input */
+    max-height: 60px;
     padding: 10px 12px;
+}
+
+
+#files-tag-filter-container.active {
+    max-height: 300px;
 }
 
 .filter-input {
@@ -1007,6 +1018,59 @@ input:autofill {
     outline: 1px solid var(--accent-primary);
     outline-offset: -2px;
     border-color: var(--border-color);
+}
+
+/* Tag filter container */
+#files-tag-filter-container .tag-filter-content {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+.tag-filter-row {
+    display: flex;
+    gap: 0.5rem;
+}
+
+#active-tag-filters {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.35rem;
+    min-height: 24px; /* to prevent layout shift */
+}
+
+.tag-filter-pill {
+    background: var(--bg-tertiary);
+    color: var(--text-secondary);
+    padding: 0.2rem 0.6rem;
+    border-radius: 12px;
+    font-size: 0.75rem;
+    display: inline-flex;
+    align-items: center;
+    border: 1px solid var(--border-color);
+}
+
+.tag-filter-pill .remove-tag-filter {
+    cursor: pointer;
+    margin-left: 0.4rem;
+    font-weight: bold;
+    font-size: 0.85rem;
+    line-height: 1;
+}
+
+.tag-filter-pill .remove-tag-filter:hover {
+    color: var(--error);
+}
+
+.tag-filter-actions {
+    display: flex;
+    gap: 0.5rem;
+}
+
+.tag-filter-actions button {
+    flex: 1;
+    padding: 0.4rem 0.8rem;
+    font-size: 0.8rem;
 }
 
 /* Sort dropdown */
@@ -3594,6 +3658,12 @@ button:disabled {
 
 :root[data-theme="light"] .filter-container.active {
     box-shadow: 0 4px 8px rgba(58, 50, 34, 0.1);
+}
+
+/* Tag filter pills in light theme */
+:root[data-theme="light"] .tag-filter-pill {
+    background: var(--bg-input-readonly);
+    border-color: var(--border-light);
 }
 
 /* Control icons in header */

--- a/static/js/files/manager.js
+++ b/static/js/files/manager.js
@@ -49,8 +49,130 @@
             
             // Set up the new file controls instead of the old filter box
             this.setupFileControls();
+            this.setupTagFilters();
         },
-        
+         
+        /**
+         * Set up tag filtering controls
+         */
+        setupTagFilters() {
+            const tagFilterBtn = document.getElementById('files-tag-filter-btn');
+            const tagFilterContainer = document.getElementById('files-tag-filter-container');
+
+            if (tagFilterBtn && tagFilterContainer) {
+                this.setupTagFilterListeners(tagFilterContainer, tagFilterBtn);
+            }
+        },
+
+        setupTagFilterListeners(container, button) {
+            const tagNameInput = container.querySelector('#tag-filter-name');
+            const tagValueInput = container.querySelector('#tag-filter-value');
+            const addBtn = container.querySelector('#add-tag-filter-btn');
+            const clearBtn = container.querySelector('#clear-tag-filters-btn');
+
+            button.addEventListener('click', () => {
+                const isActive = container.classList.contains('active');
+                
+                // Close other panes for clean UI state
+                document.getElementById('files-filter').classList.remove('active');
+                document.getElementById('files-filter-btn').classList.remove('active');
+                document.getElementById('files-sort-dropdown').classList.remove('active');
+                State.activeSortDropdown = null;
+
+                container.classList.toggle('active');
+                button.classList.toggle('active');
+                
+                if (!isActive) {
+                    tagNameInput.focus();
+                }
+            });
+
+            // Prevent Enter key from doing anything in the inputs
+            const preventEnter = (e) => {
+                if (e.key === 'Enter') {
+                    e.preventDefault();
+                    e.stopPropagation();
+                }
+            };
+            tagNameInput.addEventListener('keydown', preventEnter);
+            tagValueInput.addEventListener('keydown', preventEnter);
+
+            addBtn.addEventListener('click', (e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                
+                const tagName = tagNameInput.value.trim();
+                let tagValue = tagValueInput.value.trim();
+                
+                if (!tagName) {
+                    tagNameInput.focus();
+                    return;
+                }
+
+                if (tagValue === '') {
+                    tagValue = '/null';
+                }
+                
+                State.tagFilters = State.tagFilters || {};
+                State.tagFilters[tagName.toLowerCase()] = tagValue;
+                this.updateActiveTagFiltersUI();
+                this.queryFiles();
+                
+                // Clear inputs after adding
+                tagNameInput.value = '';
+                tagValueInput.value = '';
+                tagNameInput.focus();
+            });
+
+            clearBtn.addEventListener('click', (e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                
+                State.tagFilters = {};
+                this.updateActiveTagFiltersUI();
+                // When clearing filters, revert to the folder view if a folder is selected
+                if (State.currentPath) {
+                    this.loadFiles(State.currentPath);
+                } else {
+                    this.queryFiles();
+                }
+            });
+        },
+
+        updateActiveTagFiltersUI() {
+            const container = document.getElementById('active-tag-filters');
+            if (!container) return;
+            container.innerHTML = '';
+            State.tagFilters = State.tagFilters || {};
+            for (const [tag, value] of Object.entries(State.tagFilters)) {
+                const pill = document.createElement('div');
+                pill.className = 'tag-filter-pill';
+                const displayValue = value === '/null' ? '(empty)' : value;
+                const textNode = document.createTextNode(`${tag.charAt(0).toUpperCase() + tag.slice(1)}: ${displayValue}`);
+                pill.appendChild(textNode);
+                const removeBtn = document.createElement('span');
+                removeBtn.className = 'remove-tag-filter';
+                removeBtn.textContent = '✕';
+                removeBtn.title = 'Remove filter';
+                removeBtn.onclick = () => {
+                    delete State.tagFilters[tag];
+                    this.updateActiveTagFiltersUI();
+                    if (Object.keys(State.tagFilters).length === 0) {
+                        // No filters left, either revert to folder view or clear list
+                        if (State.currentPath) {
+                            this.loadFiles(State.currentPath);
+                        } else {
+                            this.queryFiles(); // This will clear the list
+                        }
+                    } else {
+                        this.queryFiles();
+                    }
+                };
+                pill.appendChild(removeBtn);
+                container.appendChild(pill);
+            }
+        },
+
         /**
          * Set up filter and sort controls for files pane
          */
@@ -81,8 +203,12 @@
                 // Filter input handler
                 filterInput.addEventListener('input', (e) => {
                     State.filesFilter = e.target.value;
-                    // Re-render the file list with the new filter
-                    this.renderFileList();
+                    const hasTagFilters = State.tagFilters && Object.keys(State.tagFilters).length > 0;
+                    if (hasTagFilters) {
+                        this.queryFiles(); // Server-side filtering when tags are active
+                    } else {
+                        this.renderFileList(); // Client-side filtering otherwise
+                    }
                 });
             }
             
@@ -174,6 +300,80 @@
         },
 
         /**
+         * Load and display files in a folder.
+         * @param {string} folderPath - Path to the folder
+         */
+        async loadFiles(folderPath) {
+            // When a folder is selected, reset all filters to show the folder's contents.
+            State.currentPath = folderPath;
+            State.tagFilters = {};
+            this.updateActiveTagFiltersUI();
+            State.filesFilter = '';
+            const filterInput = document.getElementById('files-filter-input');
+            if (filterInput) filterInput.value = '';
+ 
+            document.getElementById('file-count').textContent = '(loading...)';
+            AudioPlayer.stopPlayback();
+ 
+            try {
+                // This uses the original API endpoint for listing files from the filesystem.
+                const data = await API.loadFiles(folderPath);
+ 
+                State.currentFiles = data.files;
+                this.renderFileList(); // This will also update the file count
+                this.updateSortUI();
+ 
+            } catch (err) {
+                console.error('Error loading files:', err);
+                UIUtils.showStatus('Error loading files', 'error');
+                document.getElementById('file-count').textContent = '(error)';
+            }
+        },
+ 
+        /**
+         * Query files from the database with active filters.
+         */
+        async queryFiles() {
+            const filters = { ...(State.tagFilters || {}) };
+            
+            if (State.filesFilter) {
+                filters.name = State.filesFilter;
+            }
+
+            // Add folder context to the filter if a folder is selected.
+            if (State.currentPath) {
+                filters.folder = State.currentPath;
+            }
+ 
+            // If no filters are active, don't query. Show empty or revert to folder view.
+            if (Object.keys(filters).length === 0) {
+                State.currentFiles = [];
+                this.renderFileList();
+                document.getElementById('file-count').textContent = '(0)';
+                return;
+            }
+ 
+            document.getElementById('file-count').textContent = '(loading...)';
+            AudioPlayer.stopPlayback();
+ 
+            try {
+                const params = new URLSearchParams(filters);
+                const response = await fetch(`/files?${params.toString()}`);
+                if (!response.ok) throw new Error(`HTTP error ${response.status}`);
+                const data = await response.json();
+ 
+                State.currentFiles = data.files;
+                document.getElementById('file-count').textContent = `(${data.pagination.total})`;
+                this.renderFileList();
+                this.updateSortUI();
+            } catch (err) {
+                console.error('Error querying files:', err);
+                UIUtils.showStatus('Error querying files', 'error');
+                document.getElementById('file-count').textContent = '(error)';
+            }
+        },
+
+        /**
          * Format file size in human-readable format
          * @param {number} bytes - Size in bytes
          * @returns {string} Formatted size
@@ -195,38 +395,6 @@
             if (!timestamp) return 'Unknown';
             const date = new Date(timestamp * 1000);
             return date.toLocaleDateString();
-        },
-        
-        /**
-         * Load and display files in a folder
-         * @param {string} folderPath - Path to the folder
-         */
-        async loadFiles(folderPath) {
-            State.currentPath = folderPath;
-            document.getElementById('file-count').textContent = '(loading...)';
-            
-            AudioPlayer.stopPlayback();
-            
-            try {
-                const data = await API.loadFiles(folderPath);
-                
-                // Store the raw file data
-                State.currentFiles = data.files;
-                
-                // Update count before filtering
-                document.getElementById('file-count').textContent = `(${data.files.length})`;
-                
-                // Render the file list (which will apply filtering and sorting)
-                this.renderFileList();
-                
-                // Update sort UI to reflect current state
-                this.updateSortUI();
-                
-            } catch (err) {
-                console.error('Error loading files:', err);
-                UIUtils.showStatus('Error loading files', 'error');
-                document.getElementById('file-count').textContent = '(error)';
-            }
         },
         
         /**
@@ -287,8 +455,25 @@
         renderFileList() {
             const list = document.getElementById('file-list');
             list.innerHTML = '';
+
+            let filesToRender = State.currentFiles || [];
             
-            if (!State.currentFiles || State.currentFiles.length === 0) {
+            // Only apply client-side text filter if no tag filters are active.
+            const hasTagFilters = State.tagFilters && Object.keys(State.tagFilters).length > 0;
+            if (!hasTagFilters && State.filesFilter) {
+                const filterValue = State.filesFilter.toLowerCase().trim();
+                if (filterValue) {
+                    filesToRender = filesToRender.filter(file =>
+                        file.name.toLowerCase().includes(filterValue)
+                    );
+                }
+            }
+
+            if (!hasTagFilters) { // Only update count if we're not in a query view
+                document.getElementById('file-count').textContent = `(${filesToRender.length})`;
+            }
+            
+            if (filesToRender.length === 0) {
                 const li = document.createElement('li');
                 li.textContent = 'No audio files found';
                 li.style.color = '#999';
@@ -296,24 +481,9 @@
                 list.appendChild(li);
                 return;
             }
-            
-            // Apply filter
-            const filterValue = State.filesFilter.toLowerCase().trim();
-            let filteredFiles = State.currentFiles;
-            
-            if (filterValue.length > 0) {
-                filteredFiles = State.currentFiles.filter(file => 
-                    file.name.toLowerCase().includes(filterValue)
-                );
-            }
-            
-            // Update file count to show filtered count
-            document.getElementById('file-count').textContent = `(${filteredFiles.length})`;
-            
-            // Apply sorting
-            const sortedFiles = this.sortFiles(filteredFiles);
-            
-            // Render each file
+             
+            const sortedFiles = this.sortFiles(filesToRender);
+
             sortedFiles.forEach(file => {
                 const li = document.createElement('li');
                 li.dataset.filepath = file.path;
@@ -452,6 +622,7 @@
                     // A newer request has been made, discard this response
                     return;
                 }
+                
                     State.originalMetadata = {
                         title: data.title || '',
                         artist: data.artist || '',
@@ -463,7 +634,6 @@
                         track: data.track || '',
                         disc: data.disc || ''
                     };
-                    
                     
                     // Store all fields data if available, but don't overwrite standard fields
                     if (data.all_fields) {
@@ -540,7 +710,6 @@
                 if (!artDisplay) {
                     console.error('Album art display element not found!');
                 } else {
-                
                 // Check if format supports album art
                 if (!formatLimitations.supportsAlbumArt) {
                     artDisplay.innerHTML = `<div class="album-art-placeholder" style="opacity: 0.5;">Album art not supported for ${format.toUpperCase()}</div>`;

--- a/templates/index.html
+++ b/templates/index.html
@@ -83,6 +83,9 @@
                     <button class="control-icon" id="files-filter-btn" title="Filter files (/)" tabindex="0">
                         🔍
                     </button>
+                    <button class="control-icon" id="files-tag-filter-btn" title="Filter by tags" tabindex="0">
+                        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="16" height="16" fill="currentColor"><path d="M21.41 11.58l-9-9A2 2 0 0011 2H4a2 2 0 00-2 2v7a2 2 0 00.59 1.42l9 9a2 2 0 002.82 0l7-7a2 2 0 000-2.82zM6.5 8A1.5 1.5 0 118 6.5 1.5 1.5 0 016.5 8z"></path></svg>
+                    </button>
                     <div class="sort-controls">
                         <button class="control-icon sort-field-btn" id="files-sort-btn" title="Sort by: Name" tabindex="0">
                             ↕️
@@ -101,6 +104,21 @@
                 <div class="sort-option" data-sort="date">Date Modified</div>
                 <div class="sort-option" data-sort="type">Type</div>
                 <div class="sort-option" data-sort="size">Size</div>
+            </div>
+            <div class="filter-container" id="files-tag-filter-container">
+                <div class="tag-filter-content">
+                    <div class="tag-filter-row">
+                        <input type="text" id="tag-filter-name" class="filter-input" placeholder="Tag name">
+                        <input type="text" id="tag-filter-value" class="filter-input" placeholder="Value (empty for missing)">
+                    </div>
+                    <div id="active-tag-filters">
+                        <!-- Active filter pills will be added here by JS -->
+                    </div>
+                    <div class="tag-filter-actions">
+                        <button id="add-tag-filter-btn" class="apply-file-btn">Add Filter</button>
+                        <button id="clear-tag-filters-btn" class="clear-btn">Clear All</button>
+                    </div>
+                </div>
             </div>
             <div class="files-scroll-area">
                 <ul id="file-list"></ul>


### PR DESCRIPTION
## Motivation
- related issue: https://github.com/wow-signal-dev/metadata-remote/issues/41
- I wanted a way to filter by songs that don't have a certain tag filled in
- adding a db was the most feasible and scalable way to handle (alternative would've been to have all the tags in the /files/ json and iterate through when searching

## Changes Made
- Added sqlite db with initial scan to load tags in
- Added backend routes to support 
- Added UI changes to support filtering by tag

<img width="838" height="624" alt="image" src="https://github.com/user-attachments/assets/6019affc-32db-4e31-924a-caf1b432f5c6" />

## Potential Enhancements
- /files/ could query DB instead for very large libraries to take advantage of pagination
- currently tag search only goes by the folder (perhaps can expand to library wide, this wasn't a concern for me because I have all my songs in one folder)
- add UI button to trigger rescan (just a route for now)
- tag is cleared when switching folders, (toggle to make tag sticky?)
- add an apply to filtered tags option