### PR TITLE
Add feature: add album art from url

### DIFF
--- a/app.py
+++ b/app.py
@@ -39,6 +39,8 @@ import subprocess
 from werkzeug.middleware.proxy_fix import ProxyFix
 import signal
 import sys
+import requests
+import base64
 
 from config import (
     MUSIC_DIR, OWNER_UID, OWNER_GID, PORT, HOST,
@@ -843,6 +845,33 @@ def create_custom_field():
     except Exception as e:
         logger.error(f"Error creating custom field: {e}")
         return jsonify({'error': str(e)}), 500
+    
+@app.route('/image-from-url', methods=['POST'])
+def image_from_url():
+    data = request.get_json()
+    image_url = data.get('url')
+
+    if not image_url:
+        return jsonify({'status': 'error', 'error': 'No URL provided'}), 400
+
+    try:
+        headers = {'User-Agent': 'MetadataRemote/1.0'}
+        response = requests.get(image_url, stream=True, timeout=10, headers=headers)
+        response.raise_for_status() 
+
+        content_type = response.headers.get('content-type', 'image/jpeg')
+        image_data = response.content
+        base64_encoded_data = base64.b64encode(image_data).decode('utf-8')
+        
+        data_url = f"data:{content_type};base64,{base64_encoded_data}"
+
+        return jsonify({'status': 'success', 'image_data': data_url})
+
+    except requests.exceptions.RequestException as e:
+        # Handle network errors, bad URLs, etc.
+        return jsonify({'status': 'error', 'error': f"Failed to fetch image: {e}"}), 500
+    except Exception as e:
+        return jsonify({'status': 'error', 'error': f"An unexpected error occurred: {e}"}), 500
 
 @app.route('/apply-art-to-folder', methods=['POST'])
 def apply_art_to_folder():

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,5 @@ MarkupSafe==3.0.2
 mutagen==1.47.0
 Pillow>=10.0.0
 Werkzeug==3.0.1
+watchdog>=3.0.0
+requests>=2.32.5

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -1706,28 +1706,20 @@ input:autofill {
     height: 300px;
 }
 
-.upload-btn {
+.upload-btn,
+.image-link-btn {
     background: linear-gradient(135deg, #3a3a3a 0%, #4a4a4a 100%);
     color: var(--text-primary);
 }
 
-.upload-btn:hover:not(:disabled):not(.processing):not(.success):not(.error):not(.warning) {
+.upload-btn:hover:not(:disabled):not(.processing):not(.success):not(.error):not(.warning),
+.image-link-btn:hover:not(:disabled):not(.processing):not(.success):not(.error):not(.warning) {
     transform: translateY(-1px);
     box-shadow: 0 4px 12px rgba(58, 58, 58, 0.4);
 }
 
 .album-art-controls .upload-btn:disabled {
     cursor: not-allowed;
-}
-
-.save-image-btn {
-    background: linear-gradient(135deg, #2d5a2d 0%, #3a7a3a 100%);
-    color: white;
-}
-
-.save-image-btn:hover:not(.processing):not(.success):not(.error):not(.warning) {
-    transform: translateY(-1px);
-    box-shadow: 0 4px 12px rgba(45, 90, 45, 0.4);
 }
 
 .apply-folder-btn {
@@ -1752,6 +1744,60 @@ input:autofill {
 
 input[type="file"] {
     display: none;
+}
+
+.art-url-input-container {
+    display: none; /* Hidden by default, shown by JS */
+    flex-direction: column;
+    gap: 0.35rem;
+    align-items: stretch;
+    min-width: 90px;
+}
+ 
+#art-url-input {
+    width: 100%;
+    background: var(--bg-input);
+    border: 1px solid var(--border-color);
+    padding: 0.4rem 0.75rem;
+    color: var(--text-primary);
+    border-radius: 6px;
+    font-size: 0.75rem;
+}
+ 
+#art-url-input:focus {
+    outline: 1px solid var(--accent-primary);
+    outline-offset: -2px;
+    border-color: var(--border-color);
+}
+ 
+.art-url-input-container button {
+    padding: 0.4rem 0.75rem;
+    font-size: 0.75rem;
+    font-weight: 500;
+    border-radius: 6px;
+    border: none;
+    cursor: pointer;
+    flex-shrink: 0;
+}
+ 
+.art-url-submit-btn {
+    background: linear-gradient(135deg, #2d5a2d 0%, #3a7a3a 100%);
+    color: white;
+}
+ 
+.art-url-submit-btn:hover:not(:disabled) {
+    transform: translateY(-1px);
+    box-shadow: 0 2px 6px rgba(45, 90, 45, 0.4);
+}
+ 
+.art-url-cancel-btn {
+    background: linear-gradient(135deg, #5a2a2a 0%, #7a3a3a 100%);
+    color: white;
+}
+ 
+.art-url-cancel-btn:hover:not(:disabled) {
+    transform: translateY(-1px);
+    box-shadow: 0 2px 6px rgba(90, 45, 45, 0.4);
 }
 
 #metadata-form {
@@ -3175,12 +3221,14 @@ button:disabled {
 }
 
 /* Album art buttons */
-:root[data-theme="light"] .upload-btn {
+:root[data-theme="light"] .upload-btn,
+:root[data-theme="light"] .image-link-btn {
     background: linear-gradient(135deg, #b08d57 0%, #a07d47 100%);
     color: white;
 }
 
-:root[data-theme="light"] .upload-btn:hover:not(.processing):not(.success):not(.error):not(.warning) {
+:root[data-theme="light"] .upload-btn:hover:not(.processing):not(.success):not(.error):not(.warning),
+:root[data-theme="light"] .image-link-btn:hover:not(.processing):not(.success):not(.error):not(.warning) {
     background: linear-gradient(135deg, #a07d47 0%, #906d37 100%);
     box-shadow: 0 4px 12px rgba(176, 141, 87, 0.4);
 }

--- a/static/js/api.js
+++ b/static/js/api.js
@@ -182,5 +182,14 @@ window.MetadataRemote.API = {
                 field_value: fieldValue
             })
         });
+    },
+    
+    // Fetch image from URL via backend proxy
+    async getImageFromUrl(imageUrl) {
+        return this.call('/image-from-url', {
+            method: 'POST',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify({ url: imageUrl })
+        });
     }
 };

--- a/static/js/metadata/album-art.js
+++ b/static/js/metadata/album-art.js
@@ -136,10 +136,12 @@
                 document.querySelector('.delete-art-btn').style.display = 'block';
                 document.querySelector('.save-image-btn').style.display = 'block';
                 document.querySelector('.apply-folder-btn').style.display = 'block';
+                document.querySelector('.image-link-btn').style.display = 'none';
                 
                 showStatusCallback('Image loaded. Click "Save Image" to save only the image, or "Save" to save all changes.', 'success');
             };
             reader.readAsDataURL(file);
+            
             
             event.target.value = '';
         },
@@ -166,6 +168,7 @@
                     document.querySelector('.delete-art-btn').style.display = 'none';
                     document.querySelector('.save-image-btn').style.display = 'none';
                     document.querySelector('.apply-folder-btn').style.display = 'none';
+                    document.querySelector('.image-link-btn').style.display = 'block';
                     
                     ButtonStatus.showButtonStatus(button, 'Deleted!', 'success', 2000);
                     loadHistoryCallback();
@@ -205,6 +208,7 @@
                     setTimeout(() => {
                         document.querySelector('.save-image-btn').style.display = 'none';
                         document.querySelector('.apply-folder-btn').style.display = 'none';
+                        document.querySelector('.image-link-btn').style.display = 'block';
                         
                         // Return focus to upload button after buttons are hidden
                         const uploadBtn = document.querySelector('.upload-btn');
@@ -272,6 +276,74 @@
             
             button.disabled = false;
             setFormEnabledCallback(true);
+        },
+
+        /**
+         * Show the album art URL input field
+         */
+        showArtUrlInput() {
+            document.querySelector('.album-art-controls').style.display = 'none';
+            const container = document.getElementById('art-url-input-container');
+            if (container) {
+                container.style.display = 'flex';
+                document.getElementById('art-url-input').focus();
+            }
+        },
+
+        /**
+         * Hide the album art URL input field
+         */
+        hideArtUrlInput() {
+            document.querySelector('.album-art-controls').style.display = 'flex';
+            const container = document.getElementById('art-url-input-container');
+            if (container) {
+                container.style.display = 'none';
+                document.getElementById('art-url-input').value = '';
+            }
+        },
+
+        /**
+         * Submit album art from a URL
+         */
+        async submitArtUrl() {
+            const urlInput = document.getElementById('art-url-input');
+            const artUrl = urlInput.value.trim();
+            if (!artUrl) {
+                showStatusCallback('Please enter an image URL.', 'error');
+                return;
+            }
+            
+            const button = document.querySelector('.art-url-submit-btn');
+            button.disabled = true;
+            ButtonStatus.showButtonStatus(button, 'Fetching...', 'processing');
+            
+            try {
+                const result = await API.getImageFromUrl(artUrl);
+                
+                if (result.status === 'success' && result.image_data) {
+                    State.pendingAlbumArt = result.image_data;
+                    
+                    const artDisplay = document.getElementById('art-display');
+                    this.displayAlbumArtWithMetadata(State.pendingAlbumArt, artDisplay);
+                    
+                    // Hide URL input and show regular controls, mimicking local upload
+                    this.hideArtUrlInput();
+                    document.querySelector('.delete-art-btn').style.display = 'block';
+                    document.querySelector('.save-image-btn').style.display = 'block';
+                    document.querySelector('.apply-folder-btn').style.display = 'block';
+                    document.querySelector('.image-link-btn').style.display = 'none';
+                    
+                    showStatusCallback('Image loaded. Click "Apply to file" to save only the image, or "Save all fields" to save all changes.', 'success');
+                    ButtonStatus.showButtonStatus(button, 'Loaded!', 'success', 1500);
+                } else {
+                    ButtonStatus.showButtonStatus(button, result.error || 'Fetch failed', 'error');
+                }
+            } catch (err) {
+                console.error('Error fetching album art from URL:', err);
+                ButtonStatus.showButtonStatus(button, 'Fetch Error', 'error');
+            }
+            
+            button.disabled = false;
         }
     };
 })();

--- a/templates/index.html
+++ b/templates/index.html
@@ -144,6 +144,7 @@
                             </div>
                             <div class="album-art-controls">
                                 <button class="upload-btn" onclick="document.getElementById('art-upload').click()">Upload</button>
+                                <button class="image-link-btn" onclick="window.MetadataRemote.Metadata.AlbumArt.showArtUrlInput()">Image Link</button>
                                 <button class="save-image-btn btn-status" onclick="saveAlbumArt()" style="display: none;">
                                     <span class="btn-status-content">Apply to file</span>
                                     <span class="btn-status-message"></span>
@@ -157,6 +158,14 @@
                                     <span class="btn-status-message"></span>
                                 </button>
                                 <input type="file" id="art-upload" accept="image/*" onchange="handleArtUpload(event)">
+                            </div>
+                            <div class="art-url-input-container" id="art-url-input-container" style="display: none;">
+                                <input type="url" id="art-url-input" placeholder="Paste image URL here">
+                                <button class="art-url-submit-btn btn-status" onclick="window.MetadataRemote.Metadata.AlbumArt.submitArtUrl()">
+                                    <span class="btn-status-content">Submit</span>
+                                    <span class="btn-status-message"></span>
+                                </button>
+                                <button class="art-url-cancel-btn" onclick="window.MetadataRemote.Metadata.AlbumArt.hideArtUrlInput()">Cancel</button>
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
## Motivation
- Don't want to have to download images to local and then upload them to tool, saves a step and space on local machine

## Changes made
- added image-from-url route to fetch the base64 encoded image
- added api in front end to call said route
- added button in album art view to submit the url

<img width="818" height="418" alt="image" src="https://github.com/user-attachments/assets/cd0dcefa-3cfe-474f-8919-09a4e34fa912" />
