### PR TITLE
feat: improve file/folder management with delete actions and in-app error dialogs

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -1082,6 +1082,120 @@ input:autofill {
     overflow: hidden;
 }
 
+.tree-item-content.drag-over {
+    background: var(--bg-hover);
+}
+
+.tree-item-content.drag-over.drag-copy {
+    outline: 1px solid rgba(74, 127, 255, 0.6);
+    outline-offset: -1px;
+}
+
+.tree-item.dragging .tree-item-content,
+#file-list li.dragging {
+    opacity: 0.6;
+}
+
+.drag-image {
+    position: fixed;
+    top: -9999px;
+    left: -9999px;
+    padding: 0.25rem 0.5rem;
+    border-radius: 6px;
+    background: rgba(30, 30, 30, 0.85);
+    border: 1px solid rgba(74, 127, 255, 0.65);
+    color: var(--text-primary);
+    font-size: 0.85rem;
+    white-space: nowrap;
+    pointer-events: none;
+    box-shadow: 0 8px 22px rgba(0, 0, 0, 0.55);
+    backdrop-filter: blur(6px);
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+}
+
+.drag-image-badge {
+    margin-left: 0.25rem;
+    padding: 0.05rem 0.35rem;
+    border-radius: 999px;
+    background: rgba(74, 127, 255, 0.25);
+    border: 1px solid rgba(74, 127, 255, 0.55);
+    color: #cfe0ff;
+    font-weight: 600;
+    font-size: 0.8rem;
+    line-height: 1.1;
+}
+
+:root[data-theme="light"] .drag-image {
+    background: rgba(244, 241, 222, 0.95);
+    border: 1px solid rgba(74, 127, 255, 0.45);
+    color: #3a3222;
+}
+
+:root[data-theme="light"] .drag-image-badge {
+    background: rgba(74, 127, 255, 0.12);
+    border: 1px solid rgba(74, 127, 255, 0.35);
+    color: #2b4f9d;
+}
+
+.item-actions-btn {
+    width: 18px;
+    height: 18px;
+    padding: 0;
+    margin-left: 0.35rem;
+    border: none;
+    background: transparent;
+    color: var(--text-muted);
+    cursor: pointer;
+    flex-shrink: 0;
+    line-height: 1;
+    font-size: 16px;
+}
+
+.item-actions-btn:hover {
+    color: var(--text-primary);
+    background: rgba(255, 255, 255, 0.08);
+    border-radius: 4px;
+}
+
+.item-actions-menu {
+    display: none;
+    position: fixed;
+    top: 0;
+    left: 0;
+    min-width: 130px;
+    background: var(--bg-secondary);
+    border: 1px solid var(--border-color);
+    border-radius: 6px;
+    padding: 0.25rem 0;
+    box-shadow: 0 8px 20px rgba(0, 0, 0, 0.35);
+    z-index: 200;
+}
+
+.item-actions-menu.active {
+    display: block;
+}
+
+.item-actions-menu button {
+    width: 100%;
+    border: none;
+    background: transparent;
+    color: var(--text-primary);
+    text-align: left;
+    padding: 0.4rem 0.75rem;
+    font-size: 0.85rem;
+    cursor: pointer;
+}
+
+.item-actions-menu button:hover {
+    background: var(--bg-hover);
+}
+
+.item-actions-menu button.danger {
+    color: #ff6b6b;
+}
+
 .tree-item-content::before {
     content: '';
     position: absolute;
@@ -1100,6 +1214,11 @@ input:autofill {
 
 .tree-item.selected > .tree-item-content {
     background: linear-gradient(90deg, rgba(74, 127, 255, 0.1) 0%, rgba(74, 127, 255, 0.03) 100%);
+    color: var(--text-primary);
+}
+
+.tree-item.multi-selected > .tree-item-content {
+    background: linear-gradient(90deg, rgba(74, 127, 255, 0.08) 0%, rgba(74, 127, 255, 0.02) 100%);
     color: var(--text-primary);
 }
 
@@ -1193,10 +1312,66 @@ input:autofill {
     min-width: 20px;
 }
 
-.tree-rename-save.btn-status.processing,
-.tree-rename-save.btn-status.success,
-.tree-rename-save.btn-status.error {
-    min-width: 80px;
+/* File rename styling (match folder rename) */
+.file-rename-edit {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+    flex: 1;
+}
+
+.file-rename-input {
+    flex: 1;
+    padding: 0rem 0.5rem;
+    height: 20px;
+    border: 1px solid var(--border-color);
+    border-radius: 4px;
+    background: var(--bg-input);
+    color: var(--text-primary);
+    font-size: 0.85rem;
+}
+
+.file-rename-input:focus {
+    outline: 1px solid var(--accent-primary);
+    outline-offset: -2px;
+    border-color: var(--border-color);
+}
+
+.file-rename-btn {
+    width: 20px;
+    height: 20px;
+    padding: 0;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 0.75rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.file-rename-save {
+    background: linear-gradient(135deg, #2d5a2d 0%, #3a7a3a 100%);
+    color: white;
+    margin-left: auto;
+}
+
+.file-rename-save:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 2px 6px rgba(45, 90, 45, 0.4);
+}
+
+.file-rename-cancel {
+    background: linear-gradient(135deg, #5a2a2a 0%, #7a3a3a 100%);
+    color: white;
+}
+
+.file-rename-cancel:hover {
+    transform: rotate(90deg);
+}
+
+.file-rename-save.btn-status {
+    min-width: 20px;
 }
 
 .tree-children {
@@ -1225,6 +1400,21 @@ input:autofill {
     flex: 1;
     overflow-y: auto;
     overflow-x: hidden;
+}
+
+.pane-footer {
+    padding: 0.35rem 1.25rem;
+    border-top: 1px solid rgba(255, 255, 255, 0.06);
+    color: var(--text-muted);
+    font-size: 0.8rem;
+    background: var(--bg-tertiary);
+    user-select: none;
+}
+
+:root[data-theme="light"] .pane-footer {
+    border-top: 1px solid rgba(58, 50, 34, 0.12);
+    background: rgba(244, 241, 222, 0.8);
+    color: rgba(58, 50, 34, 0.75);
 }
 
 /* File count styling update */
@@ -1272,6 +1462,15 @@ input:autofill {
     color: var(--text-primary);
 }
 
+#file-list li.multi-selected {
+    background: linear-gradient(90deg, rgba(74, 127, 255, 0.08) 0%, rgba(74, 127, 255, 0.02) 100%);
+    color: var(--text-primary);
+}
+
+#file-list li.multi-selected::before {
+    transform: translateX(0);
+}
+
 #file-list li.selected.keyboard-focus {
     background: linear-gradient(90deg, rgba(74, 127, 255, 0.15) 0%, rgba(74, 127, 255, 0.05) 100%);
     outline: 1px solid var(--accent-primary);
@@ -1294,6 +1493,17 @@ input:autofill {
 .file-info {
     flex: 1;
     min-width: 0;
+}
+
+.file-row-controls {
+    display: flex;
+    align-items: center;
+    margin-left: auto;
+    gap: 0.35rem;
+}
+
+.file-row-controls .play-button {
+    margin-left: 0;
 }
 
 .file-folder {
@@ -2816,6 +3026,108 @@ button:disabled {
         max-width: none;
     }
 }
+
+/* App Dialog Modal (reuses Field Edit Modal styling) */
+.app-dialog-overlay {
+    z-index: 1001;
+}
+
+/*
+ * Use a more specific selector than `.field-edit-box` so these
+ * overrides win even though Field Edit styles appear later.
+ */
+.field-edit-box.app-dialog-box {
+    width: min(92vw, 680px);
+    min-width: 320px;
+    max-width: 92vw;
+    z-index: 1002;
+}
+
+.app-dialog-title {
+    color: var(--text-primary);
+    font-weight: 600;
+}
+
+.field-edit-content.app-dialog-content {
+    min-height: 0;
+    max-height: 60vh;
+}
+
+.app-dialog-body {
+    color: var(--text-secondary);
+    font-size: 0.9rem;
+    white-space: pre-wrap;
+    line-height: 1.35;
+    overflow-wrap: anywhere;
+    word-break: break-word;
+}
+
+.app-dialog-body.monospace {
+    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+    font-size: 0.85rem;
+}
+
+.app-dialog-confirm {
+    background: var(--accent-primary);
+    border-color: var(--accent-primary);
+    color: white;
+}
+
+.app-dialog-confirm:hover:not(:disabled) {
+    background: var(--accent-hover);
+    border-color: var(--accent-hover);
+}
+
+.app-dialog-confirm.danger {
+    background: rgba(255, 107, 107, 0.12);
+    border-color: var(--error);
+    color: var(--error);
+}
+
+.app-dialog-confirm.danger:hover:not(:disabled) {
+    background: rgba(255, 107, 107, 0.2);
+}
+
+.bulk-progress {
+    position: fixed;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    padding: 0.35rem 1.25rem 0.5rem;
+    background: var(--bg-tertiary);
+    border-top: 1px solid rgba(255, 255, 255, 0.06);
+    z-index: 900;
+}
+
+.bulk-progress-text {
+    color: var(--text-muted);
+    font-size: 0.8rem;
+    margin-bottom: 0.25rem;
+}
+
+.bulk-progress-bar {
+    height: 6px;
+    background: rgba(255, 255, 255, 0.08);
+    border-radius: 999px;
+    overflow: hidden;
+}
+
+.bulk-progress-bar-fill {
+    height: 100%;
+    width: 0%;
+    background: var(--accent-primary);
+    transition: width 120ms linear;
+}
+
+:root[data-theme="light"] .bulk-progress {
+    background: rgba(244, 241, 222, 0.92);
+    border-top: 1px solid rgba(58, 50, 34, 0.12);
+}
+
+:root[data-theme="light"] .bulk-progress-bar {
+    background: rgba(58, 50, 34, 0.10);
+}
+
 
 /* Field Edit Modal */
 .field-edit-overlay {

--- a/static/js/history/manager.js
+++ b/static/js/history/manager.js
@@ -532,7 +532,16 @@
          * Clear all history
          */
         async clearHistory() {
-            if (!confirm('Are you sure you want to clear all editing history? This action cannot be undone.')) {
+            const Dialog = window.MetadataRemote.UI.Dialog;
+            const ok = Dialog ? await Dialog.confirm({
+                title: 'Clear history',
+                message: 'Are you sure you want to clear all editing history? This action cannot be undone.',
+                confirmText: 'Clear',
+                cancelText: 'Cancel',
+                danger: true
+            }) : false;
+
+            if (!ok) {
                 return;
             }
             

--- a/static/js/navigation/contexts/list-navigation.js
+++ b/static/js/navigation/contexts/list-navigation.js
@@ -89,6 +89,34 @@
                 );
             });
             
+            // Ctrl+A selects all files (Windows-style)
+            ['div', 'li'].forEach(target => {
+                Router.register(
+                    { key: 'a', state: 'normal', context: { pane: ['files'] }, target: target, modifiers: { ctrl: true } },
+                    (event) => {
+                        const FilesManager = window.MetadataRemote.Files.Manager;
+                        if (FilesManager && FilesManager.selectAllFiles) {
+                            FilesManager.selectAllFiles();
+                        }
+                    },
+                    { priority: 75 }
+                );
+            });
+
+            // Ctrl+A selects all folders (Windows-style)
+            ['div', 'li'].forEach(target => {
+                Router.register(
+                    { key: 'a', state: 'normal', context: { pane: ['folders'] }, target: target, modifiers: { ctrl: true } },
+                    (event) => {
+                        const TreeNav = window.MetadataRemote.Navigation.Tree;
+                        if (TreeNav && TreeNav.selectAllFolders) {
+                            TreeNav.selectAllFolders();
+                        }
+                    },
+                    { priority: 75 }
+                );
+            });
+
             // Enter key
             Router.register(
                 { key: 'Enter', state: 'normal', context: { pane: ['folders', 'files'] } },

--- a/static/js/navigation/keyboard.js
+++ b/static/js/navigation/keyboard.js
@@ -560,6 +560,33 @@
                 }
             );
             
+            // DELETE for file/folder deletion (Windows-style)
+            Router.register(
+                {
+                    key: 'Delete',
+                    state: '*',
+                    context: { pane: ['folders', 'files'] }
+                },
+                (event) => {
+                    // Don't activate if in input/textarea
+                    if (event.target.tagName === 'INPUT' || event.target.tagName === 'TEXTAREA') {
+                        return;
+                    }
+
+                    const FilesManager = window.MetadataRemote.Files.Manager;
+                    const TreeNav = window.MetadataRemote.Navigation.Tree;
+
+                    (async () => {
+                        if (State.focusedPane === 'files' && FilesManager && FilesManager.deleteSelectedFiles) {
+                            await FilesManager.deleteSelectedFiles();
+                        } else if (State.focusedPane === 'folders' && TreeNav && TreeNav.deleteSelectedFolders) {
+                            await TreeNav.deleteSelectedFolders();
+                        }
+                    })();
+                },
+                { priority: 79 }
+            );
+
             // SHIFT+DELETE for metadata field deletion
             Router.register(
                 { 

--- a/static/js/ui/dialog.js
+++ b/static/js/ui/dialog.js
@@ -1,0 +1,308 @@
+/*
+ * Metadata Remote - Intelligent audio metadata editor
+ * Copyright (C) 2025 Dr. William Nelson Leonard
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * App Dialog Module
+ * Provides in-app confirm and list dialogs.
+ */
+
+(function() {
+    window.MetadataRemote = window.MetadataRemote || {};
+    window.MetadataRemote.UI = window.MetadataRemote.UI || {};
+
+    const getEl = (id) => document.getElementById(id);
+
+    const copyTextToClipboard = async (text) => {
+        if (navigator.clipboard && navigator.clipboard.writeText) {
+            await navigator.clipboard.writeText(text);
+            return;
+        }
+
+        const textarea = document.createElement('textarea');
+        textarea.value = text;
+        textarea.style.position = 'fixed';
+        textarea.style.left = '-9999px';
+        document.body.appendChild(textarea);
+        textarea.focus();
+        textarea.select();
+        document.execCommand('copy');
+        textarea.remove();
+    };
+
+    const Dialog = {
+        overlay: null,
+        box: null,
+        titleEl: null,
+        bodyEl: null,
+        copyBtn: null,
+        cancelBtn: null,
+        confirmBtn: null,
+        isOpenFlag: false,
+        resolve: null,
+        keyHandler: null,
+
+        init() {
+            this.overlay = getEl('app-dialog-overlay');
+            this.box = getEl('app-dialog-box');
+            this.titleEl = getEl('app-dialog-title');
+            this.bodyEl = getEl('app-dialog-body');
+            this.copyBtn = getEl('app-dialog-copy');
+            this.cancelBtn = getEl('app-dialog-cancel');
+            this.confirmBtn = getEl('app-dialog-confirm');
+
+            if (!this.overlay || !this.box) {
+                return;
+            }
+
+            this.overlay.addEventListener('click', () => {
+                this.close(false);
+            });
+
+            this.cancelBtn.addEventListener('click', () => {
+                this.close(false);
+            });
+
+            this.confirmBtn.addEventListener('click', () => {
+                this.close(true);
+            });
+        },
+
+        isOpen() {
+            return this.isOpenFlag;
+        },
+
+        openBase({ title, bodyText, confirmText, cancelText, danger = false, showCopy = false, copyText = '', showCancel = true, monospace = false, disableConfirm = false }) {
+            if (!this.overlay || !this.box || this.isOpen()) {
+                return Promise.resolve(false);
+            }
+
+            this.isOpenFlag = true;
+
+            this.titleEl.textContent = title || '';
+            this.bodyEl.textContent = bodyText || '';
+            this.bodyEl.classList.toggle('monospace', Boolean(monospace));
+
+            this.confirmBtn.textContent = confirmText || 'OK';
+            this.cancelBtn.textContent = cancelText || 'Cancel';
+
+            this.cancelBtn.style.display = showCancel ? 'inline-flex' : 'none';
+
+            this.confirmBtn.classList.toggle('danger', Boolean(danger));
+            this.confirmBtn.disabled = Boolean(disableConfirm);
+
+            this.copyBtn.style.display = showCopy ? 'inline-flex' : 'none';
+            this.copyBtn.onclick = null;
+
+            if (showCopy) {
+                const ButtonStatus = window.MetadataRemote.UI.ButtonStatus;
+
+                this.copyBtn.onclick = async () => {
+                    try {
+                        await copyTextToClipboard(copyText);
+                        if (ButtonStatus) {
+                            ButtonStatus.showButtonStatus(this.copyBtn, 'Copied', 'success', 1200);
+                        }
+                    } catch (err) {
+                        if (ButtonStatus) {
+                            ButtonStatus.showButtonStatus(this.copyBtn, 'Copy failed', 'error', 2000);
+                        }
+                    }
+                };
+            }
+
+            this.overlay.classList.add('active');
+            this.box.classList.add('active');
+
+            this.keyHandler = (e) => {
+                if (!this.isOpen()) return;
+
+                if (e.key === 'Escape') {
+                    e.preventDefault();
+                    this.close(false);
+                    return;
+                }
+
+                if (e.key === 'Enter') {
+                    const active = document.activeElement;
+                    if (active === this.cancelBtn) {
+                        return;
+                    }
+
+                    if (this.confirmBtn.disabled) {
+                        return;
+                    }
+
+                    e.preventDefault();
+                    this.close(true);
+                    return;
+                }
+
+                 if (e.key === 'Tab') {
+                     const focusable = [this.copyBtn, this.cancelBtn, this.confirmBtn].filter(btn => btn && btn.offsetParent !== null && btn.style.display !== 'none');
+                     if (focusable.length === 0) return;
+
+
+                    const currentIndex = focusable.indexOf(document.activeElement);
+                    let nextIndex = currentIndex;
+
+                    if (e.shiftKey) {
+                        nextIndex = currentIndex <= 0 ? focusable.length - 1 : currentIndex - 1;
+                    } else {
+                        nextIndex = currentIndex === focusable.length - 1 ? 0 : currentIndex + 1;
+                    }
+
+                    if (nextIndex !== -1) {
+                        e.preventDefault();
+                        focusable[nextIndex].focus();
+                    }
+                }
+            };
+
+            document.addEventListener('keydown', this.keyHandler, true);
+
+            return new Promise((resolve) => {
+                this.resolve = resolve;
+
+                setTimeout(() => {
+                    this.confirmBtn.focus();
+                }, 0);
+            });
+        },
+
+        close(result) {
+            if (!this.isOpen()) {
+                return;
+            }
+
+            this.overlay.classList.remove('active');
+            this.box.classList.remove('active');
+
+
+            if (this.keyHandler) {
+                document.removeEventListener('keydown', this.keyHandler, true);
+                this.keyHandler = null;
+            }
+
+            this.isOpenFlag = false;
+
+            if (this.resolve) {
+                const resolve = this.resolve;
+                this.resolve = null;
+                resolve(Boolean(result));
+            }
+        },
+
+        confirm({ title = 'Confirm', message = '', confirmText = 'OK', cancelText = 'Cancel', danger = false }) {
+            return this.openBase({
+                title,
+                bodyText: message,
+                confirmText,
+                cancelText,
+                danger,
+                showCopy: false,
+                copyText: '',
+                showCancel: true
+            });
+        },
+
+        update({ title = null, bodyText = null, monospace = null } = {}) {
+            if (!this.isOpen()) {
+                return;
+            }
+
+            if (title !== null && this.titleEl) {
+                this.titleEl.textContent = title;
+            }
+
+            if (bodyText !== null && this.bodyEl) {
+                this.bodyEl.textContent = bodyText;
+            }
+
+            if (monospace !== null && this.bodyEl) {
+                this.bodyEl.classList.toggle('monospace', Boolean(monospace));
+            }
+        },
+
+        showLoading({ title = 'Please wait', message = 'Working...', cancelText = 'Cancel', monospace = false } = {}) {
+            return this.openBase({
+                title,
+                bodyText: message,
+                confirmText: 'Loading…',
+                cancelText,
+                danger: false,
+                showCopy: false,
+                copyText: '',
+                showCancel: true,
+                monospace,
+                disableConfirm: true
+            });
+        },
+
+        alert({ title = 'Message', message = '', confirmText = 'OK' }) {
+            return this.openBase({
+                title,
+                bodyText: message,
+                confirmText,
+                cancelText: '',
+                danger: false,
+                showCopy: false,
+                copyText: '',
+                showCancel: false
+            });
+        },
+
+        showConflicts({ title = 'Conflicts', intro = '', items = [] }) {
+            const body = intro + (intro ? '\n\n' : '') + items.join('\n');
+            const copyText = body;
+
+            return this.openBase({
+                title,
+                bodyText: body,
+                confirmText: 'OK',
+                cancelText: 'Close',
+                danger: false,
+                showCopy: true,
+                copyText,
+                showCancel: true
+            }).then(() => {});
+        },
+
+        confirmList({ title = 'Confirm', intro = '', items = [], confirmText = 'OK', cancelText = 'Cancel', danger = false, icon = '', showCopy = false, monospace = false }) {
+            const body = intro + (intro ? '\n\n' : '') + items.join('\n');
+            const finalTitle = icon ? `${icon} ${title}` : title;
+
+            return this.openBase({
+                title: finalTitle,
+                bodyText: body,
+                confirmText,
+                cancelText,
+                danger,
+                showCopy,
+                copyText: body,
+                showCancel: true,
+                monospace
+            });
+        }
+    };
+
+    window.MetadataRemote.UI.Dialog = Dialog;
+
+    document.addEventListener('DOMContentLoaded', () => {
+        Dialog.init();
+    });
+})();

--- a/templates/index.html
+++ b/templates/index.html
@@ -43,6 +43,13 @@
         <button class="help-button" id="help-button" title="Show keyboard shortcuts" tabindex="0"><b>?</b></button>
     </div>
     
+    <div class="bulk-progress" id="bulk-progress" style="display: none;" aria-live="polite">
+        <div class="bulk-progress-text" id="bulk-progress-text"></div>
+        <div class="bulk-progress-bar">
+            <div class="bulk-progress-bar-fill" id="bulk-progress-bar-fill"></div>
+        </div>
+    </div>
+
     <div class="container">
         <div class="folders" tabindex="0" id="folders-pane">
             <div class="pane-header">
@@ -72,6 +79,7 @@
             <div class="folders-scroll-area">
                 <div id="folder-tree" class="tree"></div>
             </div>
+            <div class="pane-footer" id="folders-footer">Folders: 0 | Files: 0 | Size: 0 GB</div>
         </div>
         
         <div class="divider" id="divider1"></div>
@@ -105,6 +113,7 @@
             <div class="files-scroll-area">
                 <ul id="file-list"></ul>
             </div>
+            <div class="pane-footer" id="files-footer">Folders: 0 | Files: 0 | Size: 0 GB</div>
         </div>
         
         <div class="divider" id="divider2"></div>
@@ -336,6 +345,46 @@
                 </div>
                 
                 <div class="help-section">
+                    <h3 class="help-section-title">Selection</h3>
+                    <div class="help-shortcut-list">
+                        <div class="help-shortcut-item">
+                            <span class="help-description">Toggle selection</span>
+                            <span class="help-keys"><span class="help-key">Ctrl</span>+<span class="help-key">Click</span></span>
+                        </div>
+                        <div class="help-shortcut-item">
+                            <span class="help-description">Select range</span>
+                            <span class="help-keys"><span class="help-key">Shift</span>+<span class="help-key">Click</span></span>
+                        </div>
+                        <div class="help-shortcut-item">
+                            <span class="help-description">Add range</span>
+                            <span class="help-keys"><span class="help-key">Ctrl</span><span class="help-key-plus">+</span><span class="help-key">Shift</span>+<span class="help-key">Click</span></span>
+                        </div>
+                        <div class="help-shortcut-item">
+                            <span class="help-description">Select all (pane)</span>
+                            <span class="help-keys"><span class="help-key">Ctrl</span><span class="help-key-plus">+</span><span class="help-key">A</span></span>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="help-section">
+                    <h3 class="help-section-title">File management</h3>
+                    <div class="help-shortcut-list">
+                        <div class="help-shortcut-item">
+                            <span class="help-description">Delete selected</span>
+                            <span class="help-keys"><span class="help-key">Delete</span></span>
+                        </div>
+                        <div class="help-shortcut-item">
+                            <span class="help-description">Drag to move</span>
+                            <span class="help-keys"><span class="help-key">Drag</span></span>
+                        </div>
+                        <div class="help-shortcut-item">
+                            <span class="help-description">Drag to copy</span>
+                            <span class="help-keys"><span class="help-key">Ctrl</span><span class="help-key-plus">+</span><span class="help-key">Drag</span></span>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="help-section">
                     <h3 class="help-section-title">Sorting</h3>
                     <div class="help-shortcut-list">
                         <div class="help-shortcut-item">
@@ -419,6 +468,27 @@
             </button>
         </div>
     </div>
+
+    <!-- App Dialog Modal (reuses Field Edit Modal styling) -->
+    <div class="field-edit-overlay app-dialog-overlay" id="app-dialog-overlay" role="presentation"></div>
+    <div class="field-edit-box app-dialog-box" id="app-dialog-box" role="dialog" aria-modal="true" aria-labelledby="app-dialog-title">
+        <div class="field-edit-header app-dialog-header">
+            <span class="app-dialog-title" id="app-dialog-title"></span>
+        </div>
+
+        <div class="field-edit-content app-dialog-content">
+            <div class="app-dialog-body" id="app-dialog-body"></div>
+        </div>
+
+        <div class="field-edit-actions app-dialog-actions" id="app-dialog-actions">
+            <button class="field-edit-btn app-dialog-copy btn-status" id="app-dialog-copy" type="button" style="display: none;">
+                <span class="btn-status-content">Copy</span>
+                <span class="btn-status-message"></span>
+            </button>
+            <button class="field-edit-btn app-dialog-cancel" id="app-dialog-cancel" type="button">Cancel</button>
+            <button class="field-edit-btn app-dialog-confirm" id="app-dialog-confirm" type="button">OK</button>
+        </div>
+    </div>
   
     <!-- Core modules -->
     <script src="{{ url_for('static', filename='js/state.js') }}"></script>
@@ -427,6 +497,7 @@
     <!-- UI modules -->
     <script src="{{ url_for('static', filename='js/ui/button-status.js') }}"></script>
     <script src="{{ url_for('static', filename='js/ui/utilities.js') }}"></script>
+    <script src="{{ url_for('static', filename='js/ui/dialog.js') }}"></script>
     <script src="{{ url_for('static', filename='js/ui/pane-resize.js') }}"></script>
     <script src="{{ url_for('static', filename='js/ui/filter-sort.js') }}"></script>
     <script src="{{ url_for('static', filename='js/ui/theme-toggle.js') }}"></script>


### PR DESCRIPTION
this pr solves #49 #53

- Added ⋮ actions menu for files and folders (also on right-click) with Rename and Delete.
- Implemented in-app modal dialog system and migrated confirmations/errors to it.
- File rename is now inline in the file list and does not reset unsaved metadata edits.
- Folder rename supports merge when the destination exists, with a full conflict list shown in the dialog.
- Permanent delete for files/folders (folders recursive) with bulk delete support and a bottom progress bar (stops on first error).
- Folder delete confirmation shows a tree preview of contained subfolders/files (preview is cancelable while building).
- Drag & drop:
  - Drop file/folder onto folder to move
  - Ctrl while dragging to copy (with “+” indicator)
- Multi-selection in both panes: Ctrl toggle, Shift range, Ctrl+A select all (active pane), Delete key to delete selection.
- Added footer stats for selection and folder totals (folders/files/size).
- All confirmations and conflict displays use in-app dialogs to keep UX consistent.
- History references are cleaned up when files are deleted/moved.

these updates are done in vibe coding