### PR TITLE
Don't treat "Performer" as an alias for Artist

### DIFF
--- a/core/metadata/mutagen_handler.py
+++ b/core/metadata/mutagen_handler.py
@@ -181,7 +181,13 @@ class MutagenHandler:
             "TPE1": {
                 "primary_name": "artist",
                 "display_name": "Artist",
-                "variations": ["artist", "artists", "performer", "performers", "lead performer", "lead artist", "main artist"],
+                # Note: TPE1 is officially "Lead performer(s)/Soloist(s)" per the ID3v2 spec, but
+                # "performer" is deliberately NOT listed as a variation here. Many taggers (and the
+                # Vorbis Comment spec used by FLAC/OGG) treat PERFORMER as a distinct field from
+                # ARTIST - crediting individual musicians/roles rather than the overall artist. A
+                # custom field named "Performer" should create its own TXXX:PERFORMER frame, not
+                # collapse into TPE1/Artist.
+                "variations": ["artist", "artists", "lead artist", "main artist"],
                 "versions": ["2.3", "2.4"],
                 "category": "essential"
             },

--- a/static/js/metadata/editor.js
+++ b/static/js/metadata/editor.js
@@ -76,8 +76,12 @@
         'track title': 'title',
         
         // Artist variations
+        // Note: "performer" is deliberately NOT mapped to artist here. Many taggers (and the
+        // Vorbis Comment spec used by FLAC/OGG) treat PERFORMER as a distinct field from ARTIST -
+        // crediting individual musicians/roles rather than the overall artist. Typing "Performer"
+        // as a field name should create/edit that custom field rather than silently redirecting
+        // into the Artist field.
         'artist': 'artist',
-        'performer': 'artist',
         'track artist': 'artist',
         
         // Album variations


### PR DESCRIPTION
## Summary

`TPE1` is officially named "Lead performer(s)/Soloist(s)" in the ID3v2 spec, so `"performer"` was listed as a variation for the artist field, in both the backend's ID3 frame lookup (`core/metadata/mutagen_handler.py`) and the frontend's field-name normalization (`static/js/metadata/editor.js`).

In practice this meant a custom field literally named "Performer" got silently redirected into Artist instead of creating its own field — and on MP3 specifically, the value was dropped entirely, because the write path keys `standard_fields` by the resolved frame ID (e.g. `"TPE1"`) while the lookup used to apply it expects the semantic field name (e.g. `"artist"`), so the value matched neither and was never written anywhere.

Many taggers (and the Vorbis Comment spec used by FLAC/OGG) treat `PERFORMER` as a field distinct from `ARTIST` — crediting individual musicians/roles (e.g. `Roy Bittan (piano)`) rather than the overall artist. Removing `"performer"` from the artist alias list lets a custom "Performer" field be created and edited on its own, on every format, instead of silently colliding with Artist.

## Test plan
- [x] Created a custom field named "Performer" on an MP3 and a FLAC file; confirmed it now writes/reads as its own `TXXX:PERFORMER` / `PERFORMER` field instead of being redirected into `TPE1`/`ARTIST`.
- [x] Confirmed the existing `Artist` field is untouched by the same operation.

## Note for reviewers
This fix was identified and written with the help of an AI coding assistant (Claude), while working on a downstream fork. Flagging that provenance in case it affects how you'd like to review it — happy to answer questions or make changes.